### PR TITLE
Merge roboport changes and improvements

### DIFF
--- a/prototypes/entity/entity-logistics.lua
+++ b/prototypes/entity/entity-logistics.lua
@@ -23,13 +23,14 @@ data:extend({
     charging_energy = "2000kW",
     logistics_radius = 37.5,
     construction_radius = 75,
-    charge_approach_distance = 5,
+    charge_approach_distance = 7,
     robot_slots_count = 7,
     material_slots_count = 7,
     stationing_offset = {0, 0},
     charging_offsets =
     {
       {-1.5, -0.5}, {1.5, -0.5}, {1.5, 1.5}, {-1.5, 1.5},
+      {-2.5, -1.5}, {2.5, -1.5}, {2.5, 2.5}, {-2.5, 2.5},
     },
     base =
     {
@@ -156,13 +157,15 @@ data:extend({
     charging_energy = "3000kW",
     logistics_radius = 50,
     construction_radius = 100,
-    charge_approach_distance = 5,
+    charge_approach_distance = 9,
     robot_slots_count = 7,
     material_slots_count = 7,
     stationing_offset = {0, 0},
     charging_offsets =
     {
       {-1.5, -0.5}, {1.5, -0.5}, {1.5, 1.5}, {-1.5, 1.5},
+      {-2.5, -1.5}, {2.5, -1.5}, {2.5, 2.5}, {-2.5, 2.5},
+      {-3.5, -2.5}, {3.5, -2.5}, {3.5, 3.5}, {-3.5, 3.5},
     },
     base =
     {

--- a/prototypes/entity/entity-logistics.lua
+++ b/prototypes/entity/entity-logistics.lua
@@ -1,5 +1,5 @@
 -- extend stock roboport, adding the fast-change group.
-data.raw.accumulator["accumulator"].fast_replaceable_group = "roboport"
+data.raw.roboport["roboport"].fast_replaceable_group = "roboport"
 
 data:extend({
   {

--- a/prototypes/entity/entity-logistics.lua
+++ b/prototypes/entity/entity-logistics.lua
@@ -1,3 +1,6 @@
+-- extend stock roboport, adding the fast-change group.
+data.raw.accumulator["accumulator"].fast_replaceable_group = "roboport"
+
 data:extend({
   {
     type = "roboport",
@@ -132,6 +135,7 @@ data:extend({
     default_total_logistic_output_signal = "signal-Y",
     default_available_construction_output_signal = "signal-Z",
     default_total_construction_output_signal = "signal-T",
+    fast_replaceable_group = "roboport",
   },
   {
     type = "roboport",
@@ -267,6 +271,7 @@ data:extend({
     default_total_logistic_output_signal = "signal-Y",
     default_available_construction_output_signal = "signal-Z",
     default_total_construction_output_signal = "signal-T",
+    fast_replaceable_group = "roboport",
   },
   
   


### PR DESCRIPTION
Here are some small changes to improve the way it could be possible to use Mk2 and Mk3 roboports a bit more effectively.

Mk 2. has 8 charging ports, Mk 3. has 12. Possible alternate balance would be 6 - 8 because with 12 charging points, in my limited testing it resulted in succesfully keeping a ~100 bot swarm nicely running, with only very rare slowdown due to waiting.

Also, made it possible to replace the stock and the upgrades in place.
